### PR TITLE
[테스트] JMeter 및 Locust 기반 1차 테스트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,10 @@ dependencies {
 
     // WebSocket Security
     implementation 'org.springframework.security:spring-security-messaging:6.3.1'
+
+    // actuator + prometheus
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/chatserver/domain/user/entity/User.java
+++ b/src/main/java/com/example/chatserver/domain/user/entity/User.java
@@ -21,7 +21,7 @@ public class User {
     @Column(name = "id")
     private Long id;
 
-    @Column(name = "email", nullable = false)
+    @Column(name = "email", nullable = false, unique = true)
     private String email;
 
     @Column(name = "password", nullable = false)

--- a/src/main/java/com/example/chatserver/global/config/RedisConfig.java
+++ b/src/main/java/com/example/chatserver/global/config/RedisConfig.java
@@ -92,6 +92,7 @@ public class RedisConfig {
     }
 
     // 구독 관리는 동적으로 수행하기 위한 간략한 빈 등록
+    // 얘는 redis pub sub 에서만 쓰이고 redis streams 에서는 활용 x
     @Bean
     public RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory redisConnectionFactory) {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();

--- a/src/main/java/com/example/chatserver/global/config/WebSocketConfig.java
+++ b/src/main/java/com/example/chatserver/global/config/WebSocketConfig.java
@@ -27,7 +27,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         registry
                 .addEndpoint("/stomp/chat")
                 .setAllowedOriginPatterns("*")
-                .withSockJS(); // 아니 얘 포스트맨 테스트 할 때는 무조건 없애야 하네... 말썽쟁이...
+                .withSockJS(); // 아니 얘 포스트맨 + 로커스트 테스트 할 때는 무조건 없애야 하네... 말썽쟁이...
     }
 
     @Override

--- a/src/main/java/com/example/chatserver/global/metric/WebSocketMetrics.java
+++ b/src/main/java/com/example/chatserver/global/metric/WebSocketMetrics.java
@@ -1,0 +1,42 @@
+package com.example.chatserver.global.metric;
+
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Component
+public class WebSocketMetrics {
+
+    // 현재 활성화된 웹소켓 연결 수를 추적
+    private final AtomicInteger activeConnections;
+    // 총 송수신된 메시지 수를 추적
+    private final Counter messageCounter;
+
+    public WebSocketMetrics(MeterRegistry meterRegistry) {
+        // 현재 활성화된 연결 수를 카운트하는 Gauge
+        this.activeConnections = meterRegistry.gauge("websocket.active.connections", new AtomicInteger(0));
+
+        // 송수신 메시지 수를 카운트하는 Counter
+        this.messageCounter = meterRegistry.counter("websocket.messages.total");
+    }
+
+    @EventListener
+    public void handleWebSocketConnectListener(SessionConnectEvent event) {
+        activeConnections.incrementAndGet();
+    }
+
+    @EventListener
+    public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
+        activeConnections.decrementAndGet();
+    }
+
+    public void incrementMessageCounter() {
+        messageCounter.increment();
+    }
+}

--- a/src/main/java/com/example/chatserver/global/metric/WebSocketMetrics.java
+++ b/src/main/java/com/example/chatserver/global/metric/WebSocketMetrics.java
@@ -28,10 +28,10 @@ public class WebSocketMetrics implements ApplicationListener<ContextRefreshedEve
         return ApplicationListener.super.supportsAsyncExecution();
     }
 
-    @Scheduled(fixedRate = 5000) // 5초마다 실행
-    public void collectMetrics() {
-        String webSocketLog = webSocketMessageBrokerStats.toString();
-        log.info("테스트: {}", webSocketLog);
-        webSocketMetricsParser.parseAndRegisterMetrics(webSocketLog);
-    }
+//    @Scheduled(fixedRate = 5000) // 5초마다 실행
+//    public void collectMetrics() {
+//        String webSocketLog = webSocketMessageBrokerStats.toString();
+//        log.info("테스트: {}", webSocketLog);
+//        webSocketMetricsParser.parseAndRegisterMetrics(webSocketLog);
+//    }
 }

--- a/src/main/java/com/example/chatserver/global/metric/WebSocketMetricsParser.java
+++ b/src/main/java/com/example/chatserver/global/metric/WebSocketMetricsParser.java
@@ -1,0 +1,92 @@
+package com.example.chatserver.global.metric;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+@RequiredArgsConstructor
+public class WebSocketMetricsParser {
+
+    private final MeterRegistry meterRegistry;
+
+    // 정규 표현식 기반 웹소켓 관련 데이터 파싱 및 메트릭 등록
+    public void parseAndRegisterMetrics(String log) {
+        parseAndRegisterWebSocketSessionMetrics(log);
+        parseAndRegisterStompSubProtocolMetrics(log);
+        parseAndRegisterChannelMetrics(log, "inboundChannel");
+        parseAndRegisterChannelMetrics(log, "outboundChannel");
+        parseAndRegisterChannelMetrics(log, "sockJsScheduler");
+    }
+
+    /**
+     * WebSocketSession
+     * 현재 세션 수 (current)
+     * 총 세션 수 (total)
+     * 비정상적으로 종료된 세션 수 (closed abnormally)
+     * @param log
+     */
+    private void parseAndRegisterWebSocketSessionMetrics(String log) {
+        Pattern pattern = Pattern.compile("WebSocketSession\\[(\\d+) current WS\\(\\d+\\)-HttpStream\\(\\d+\\)-HttpPoll\\(\\d+\\), (\\d+) total, (\\d+) closed abnormally");
+        Matcher matcher = pattern.matcher(log);
+
+        if (matcher.find()) {
+            int currentSessions = Integer.parseInt(matcher.group(1));
+            int totalSessions = Integer.parseInt(matcher.group(2));
+            int closedAbnormally = Integer.parseInt(matcher.group(3));
+
+            meterRegistry.gauge("websocket.sessions.current", currentSessions);
+            meterRegistry.gauge("websocket.sessions.total", totalSessions);
+            meterRegistry.gauge("websocket.sessions.closed_abnormally", closedAbnormally);
+        }
+    }
+
+    /**
+     * stompSubProtocol
+     * 처리된 CONNECT, CONNECTED, DISCONNECT 이벤트 수
+     * @param log
+     */
+    private void parseAndRegisterStompSubProtocolMetrics(String log) {
+        Pattern pattern = Pattern.compile("stompSubProtocol\\[processed CONNECT\\((\\d+)\\)-CONNECTED\\((\\d+)\\)-DISCONNECT\\((\\d+)\\)\\]");
+        Matcher matcher = pattern.matcher(log);
+
+        if (matcher.find()) {
+            int connectProcessed = Integer.parseInt(matcher.group(1));
+            int connectedProcessed = Integer.parseInt(matcher.group(2));
+            int disconnectProcessed = Integer.parseInt(matcher.group(3));
+
+            meterRegistry.gauge("stomp.connect.processed", connectProcessed);
+            meterRegistry.gauge("stomp.connected.processed", connectedProcessed);
+            meterRegistry.gauge("stomp.disconnect.processed", disconnectProcessed);
+        }
+    }
+
+    /**
+     * inboundChannel, outboundChannel, sockJsScheduler
+     * 풀 사이즈 (pool size)
+     * 활성 스레드 수 (active threads)
+     * 대기 중인 작업 수 (queued tasks)
+     * 완료된 작업 수 (completed tasks)
+     * @param log
+     * @param channelType
+     */
+    private void parseAndRegisterChannelMetrics(String log, String channelType) {
+        Pattern pattern = Pattern.compile(channelType + "\\[pool size = (\\d+), active threads = (\\d+), queued tasks = (\\d+), completed tasks = (\\d+)\\]");
+        Matcher matcher = pattern.matcher(log);
+
+        if (matcher.find()) {
+            int poolSize = Integer.parseInt(matcher.group(1));
+            int activeThreads = Integer.parseInt(matcher.group(2));
+            int queuedTasks = Integer.parseInt(matcher.group(3));
+            int completedTasks = Integer.parseInt(matcher.group(4));
+
+            meterRegistry.gauge(channelType + ".pool.size", poolSize);
+            meterRegistry.gauge(channelType + ".active.threads", activeThreads);
+            meterRegistry.gauge(channelType + ".queued.tasks", queuedTasks);
+            meterRegistry.gauge(channelType + ".completed.tasks", completedTasks);
+        }
+    }
+}

--- a/src/main/java/com/example/chatserver/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/chatserver/global/security/filter/JwtAuthenticationFilter.java
@@ -44,7 +44,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return;
         }
 
-        log.info("인증 시도");
+        log.info("인증 시도: {}", requestURI);
         String beforeToken = findAccessToken(request.getCookies());
         log.info("초기 토큰값: {}", beforeToken);
 

--- a/src/main/java/com/example/chatserver/global/security/service/JwtTokenService.java
+++ b/src/main/java/com/example/chatserver/global/security/service/JwtTokenService.java
@@ -27,7 +27,7 @@ public class JwtTokenService {
     private final JwtUtil jwtUtil;
     private final RedisTemplate<String, String> authTemplate;
     private final UserService userService;
-    private final long ACCESS_TOKEN_EAT = 30 * 1000L; // 1H
+    private final long ACCESS_TOKEN_EAT = 120 * 30 * 1000L; // 1H
     private final long REFRESH_TOKEN_EAT = 7 * 24 * 60 * 60 * 1000L; // 7D
 
     /**


### PR DESCRIPTION
## 테스트 툴 고찰

### Locust
- Python 기반의 스크립트 테스트 툴
- 코드 기반으로 테스트를 동작시키므로 개발자의 의도를 좀 더 유연하고 명확히 반영 가능
### JMeter
- GUI 기반의 스레드 테스트 툴
- 필요시, 플러그인 확장을 통해 Java나 JavaScript로 스크립트 추가 작성 가능
### 비교
| 항목                | Locust                        | JMeter                                  |
|---------------------|--------------------------------|-----------------------------------------|
| **테스트 방식**     | 코드 기반 (파이썬)             | GUI 기반                                |
| **유연성**          | 높음 (파이썬으로 로직 작성)     | 중간 (GUI로 시나리오 구성)               |
| **확장성**          | 높음 (대규모 트래픽 테스트 적합) | 낮음 (스레드 기반 리소스 소모)           |
| **지원 프로토콜**   | HTTP, WebSocket                | HTTP, FTP, JDBC, SOAP 등 다양한 프로토콜 |
| **진입 장벽**       | 파이썬 코딩 필요                | GUI로 비교적 쉬움                        |
| **복잡한 시나리오 작성** | 파이썬으로 세밀한 테스트 구성 | 다양한 설정과 플러그인으로 복잡한 시나리오 구성 |
| **대규모 트래픽**   | 효율적 비동기 처리              | 리소스 많이 소모                         |

### 결론
- 현재 내 상태는, Python 문법을 완벽하게 숙지하지 못한 상태
- Locust 수준의 유연성은 아니지만, JMeter의 풍부한 플러그인을 통해 WebSocket 대용량 테스트도 가능
- **단편적인 API에 대해서는 Locust, 세부 시나리오에 대해서는 JMeter로 테스트 결정**

## 테스트 수행
### Loucst 테스트 - 회원가입
#### 500 Users, 15 Ramp Up Time
![response_times_(ms)_1725289510 129](https://github.com/user-attachments/assets/cfa104df-0480-4fb3-b195-28829b206c2a)
<img width="631" alt="동시성 이슈 발생" src="https://github.com/user-attachments/assets/bfc8bcf1-cec8-4b6c-aa10-872730451226">
- 동시성 이슈 발생, 비즈니스 로직에서의 중복 가입 방지 외에도 데이터베이스 레벨의 중복 가입 방지 필요

### Locust 테스트 - 로그인 & 로그아웃
#### 500 Users, 15 Ramp Up Time
![response_times_(ms)_1725344447 31](https://github.com/user-attachments/assets/c5f45542-d116-4536-b555-cdf13cb457d8)
<img width="509" alt="테스트 실패, 응답 실패 반환은 없으나 토큰 정리 x" src="https://github.com/user-attachments/assets/36a10f83-38f1-494f-8c94-100684f66b38">
- 반복된 로그인 시도에 대한 예외 처리 필요

### Locust 테스트 - 채팅 객체 생성 및 조회
#### 1000 Users, 15 Ramp Up Time
![response_times_(ms)_1725355259 222](https://github.com/user-attachments/assets/65ccab33-24fc-4048-955f-b0f202b23cbb)
<img width="1415" alt="스크린샷 2024-09-03 오후 6 37 57" src="https://github.com/user-attachments/assets/b8af645e-7e4d-4484-8cf7-e576da2d5334">
- 채팅 객체가 기하급수적으로 증가함에 따라 채팅 객체 전체 조회에서의 오류 발생, 페이징 등의 조치 필요

### JMeter 테스트 - 로그인 후, 웹소켓 시나리오
#### 998 Users, 15 Ramp Up Time, 1 Loop Count
<img width="1440" alt="스크린샷 2024-09-06 오전 1 09 21" src="https://github.com/user-attachments/assets/4a6f7804-304d-4323-9a5e-b55a9685f90d">
<img width="1440" alt="스크린샷 2024-09-06 오전 1 09 39" src="https://github.com/user-attachments/assets/80782efa-a623-49ae-a30d-429a52c27323">
<img width="1440" alt="스크린샷 2024-09-06 오전 1 12 27" src="https://github.com/user-attachments/assets/66321144-36a9-4725-8abd-2f77658873e9">
- 반복 수행했을 떄, 웹소켓 로직과 관련해서 오류가 발생하는 경우도 존재
- 전체적으로 HTTP 요청이 WebSocket 로직보다 응답시간이 높았으나, 이는 WebSocket의 프레임 수준에 그친 비즈니스 로직 때문으로 고려
- 현 시점에서 고려할 부분은, 메세지의 신뢰성 보장이 1순위
